### PR TITLE
Created edit and update methods

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,5 +1,5 @@
 class OffersController < ApplicationController
-  before_action :set_offer, only: %i[show destroy]
+  before_action :set_offer, only: %i[show edit update destroy]
 
   def index
     @offers = policy_scope(Offer)
@@ -30,30 +30,29 @@ class OffersController < ApplicationController
     authorize @offer
 
     if @offer.save
-      redirect_to offers_path, notice: "Offer was successfully created."
+      redirect_to new_offer_path, notice: "Offer was successfully created."
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  ######## WE CURRENTLY DON'T HAVE AN EDIT OR DELETE OPTION FOR OUR OFFERS
-  # def edit
-  #   authorize @offer
-  # end
+  def edit
+    authorize @offer
+  end
 
-  # def update
-  #   authorize @offer
-  #   if @offer.update(restaurant_params)
-  #     redirect_to @offer, notice: "Offer was successfully updated"
-  #   else
-  #     render :edit, status: :unprocessable_entity
-  #   end
-  # end
+  def update
+    authorize @offer
+    if @offer.update(offer_params)
+      redirect_to offer_path(@offer), notice: "Offer was successfully updated"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   def destroy
     authorize @offer
     @offer.destroy
-    redirect_to offers_path, notice: "Offer was successfully deleted."
+    redirect_to new_offer_path, notice: "Offer was successfully deleted."
   end
 
   private

--- a/app/policies/offer_policy.rb
+++ b/app/policies/offer_policy.rb
@@ -26,14 +26,13 @@ class OfferPolicy < ApplicationPolicy
     true
   end
 
-  ######## We currently don't have an edit option yet for our offers
-  # def edit?
-  #   update?
-  # end
+  def edit?
+    update?
+  end
 
-  # def update?
-  #   ecord.user == user
-  # end
+  def update?
+    record.user == user
+  end
 
   def destroy?
     record.user == user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
-  resources :offers, only: %i[index show new create destroy] do
+  resources :offers, only: %i[index show new create edit update destroy] do
     resources :requests, only: %i[new create]
   end
 


### PR DESCRIPTION
BABY-53

-Adjusted create and destroy redirect paths
- Created edit and update methods


TO FIX:
Edit and update methods become create methods upon submitting an updated offer.